### PR TITLE
Handle stdout pipe closing

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,4 +7,15 @@ var prettyxml = concat({'encoding': 'string'}, function(d) {
   process.stdout.write(pd.xml(d));
 });
 
+process.stdout.on('error', function(err){
+	// been piped to a process that has closed stdout. e.g. more
+	if (err.code === "EPIPE") {
+		process.exit(0);
+	}
+
+  // something else, don't mask error
+	process.stderr.write(JSON.stringify(err) + '\n');
+	process.exit(1);
+});
+
 process.stdin.pipe(prettyxml);


### PR DESCRIPTION
Piping to the likes of more, and then quitting before the end of file has been reached produces

```
 events.js:85
      throw er; // Unhandled 'error' event
            ^
Error: write EPIPE
    at exports._errnoException (util.js:746:11)
    at WriteWrap.afterWrite (net.js:775:14)
```

This PR fixes this by explicitly handling EPIPE error and silently ignoring.
